### PR TITLE
Admin interface

### DIFF
--- a/entity_subscription/admin.py
+++ b/entity_subscription/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 
-from entity_subscription.models import Medium, Source, Subscription
+from entity_subscription.models import Medium, Source, Subscription, Unsubscribe
 
 
 class MediumAdmin(admin.ModelAdmin):
@@ -12,8 +12,14 @@ class SourceAdmin(admin.ModelAdmin):
 
 
 class SubscriptionAdmin(admin.ModelAdmin):
-    pass
+    list_display = ('entity', 'source', 'medium')
+
+
+class UnsubscribeAdmin(admin.ModelAdmin):
+    list_display = ('entity', 'source', 'medium')
+
 
 admin.site.register(Medium, MediumAdmin)
 admin.site.register(Source, SourceAdmin)
 admin.site.register(Subscription, SubscriptionAdmin)
+admin.site.register(Unsubscribe, UnsubscribeAdmin)

--- a/entity_subscription/admin.py
+++ b/entity_subscription/admin.py
@@ -1,0 +1,19 @@
+from django.contrib import admin
+
+from entity_subscription.models import Medium, Source, Subscription
+
+
+class MediumAdmin(admin.ModelAdmin):
+    pass
+
+
+class SourceAdmin(admin.ModelAdmin):
+    pass
+
+
+class SubscriptionAdmin(admin.ModelAdmin):
+    pass
+
+admin.site.register(Medium, MediumAdmin)
+admin.site.register(Source, SourceAdmin)
+admin.site.register(Subscription, SubscriptionAdmin)

--- a/entity_subscription/models.py
+++ b/entity_subscription/models.py
@@ -209,6 +209,13 @@ class Subscription(models.Model):
 
     objects = SubscriptionManager()
 
+    def __unicode__(self):
+        s = "{entity} to {source} by {medium}"
+        entity = self.entity.__unicode__()
+        source = self.source.__unicode__()
+        medium = self.medium.__unicode__()
+        return s.format(entity=entity, source=source, medium=medium)
+
 
 class UnsubscribeManager(models.Manager):
     def is_unsubscribed(self, source, medium, entity):

--- a/entity_subscription/models.py
+++ b/entity_subscription/models.py
@@ -242,6 +242,9 @@ class Medium(models.Model):
     display_name = models.CharField(max_length=64)
     description = models.TextField()
 
+    def __unicode__(self):
+        return self.display_name
+
 
 class Source(models.Model):
     """A category of where notifications originate from.

--- a/entity_subscription/models.py
+++ b/entity_subscription/models.py
@@ -230,7 +230,7 @@ class Unsubscribe(models.Model):
     objects = UnsubscribeManager()
 
     def __unicode__(self):
-        s = "{entity} from {source} by {email}"
+        s = "{entity} from {source} by {medium}"
         entity = self.entity.__unicode__()
         source = self.source.__unicode__()
         medium = self.medium.__unicode__()

--- a/entity_subscription/models.py
+++ b/entity_subscription/models.py
@@ -254,3 +254,6 @@ class Source(models.Model):
     name = models.CharField(max_length=64, unique=True)
     display_name = models.CharField(max_length=64)
     description = models.TextField()
+
+    def __unicode__(self):
+        return self.display_name

--- a/entity_subscription/models.py
+++ b/entity_subscription/models.py
@@ -229,6 +229,13 @@ class Unsubscribe(models.Model):
 
     objects = UnsubscribeManager()
 
+    def __unicode__(self):
+        s = "{entity} from {source} by {email}"
+        entity = self.entity.__unicode__()
+        source = self.source.__unicode__()
+        medium = self.medium.__unicode__()
+        return s.format(entity=entity, source=source, medium=medium)
+
 
 class Medium(models.Model):
     """A method of actually delivering the notification to users.

--- a/entity_subscription/tests/admin_test.py
+++ b/entity_subscription/tests/admin_test.py
@@ -1,0 +1,16 @@
+from django.contrib.admin.sites import AdminSite
+from django.test import TestCase
+
+from entity_subscription import admin
+from entity_subscription.models import Medium, Source, Subscription, Unsubscribe
+
+
+class AdminTest(TestCase):
+    def setUp(self):
+        self.site = AdminSite()
+
+    def test_all_can_be_called(self):
+        admin.MediumAdmin(Medium, self.site)
+        admin.SourceAdmin(Source, self.site)
+        admin.SubscriptionAdmin(Subscription, self.site)
+        admin.UnsubscribeAdmin(Unsubscribe, self.site)

--- a/entity_subscription/tests/models_tests.py
+++ b/entity_subscription/tests/models_tests.py
@@ -378,6 +378,11 @@ class NumberOfQueriesTests(TestCase):
 
 
 class UnicodeMethodTests(TestCase):
+    def test_medium_unicode(self):
+        medium = G(Medium, name='test', display_name='Test', description='A test medium.')
+        expected_unicode = 'Test'
+        self.assertEqual(medium.__unicode__(), expected_unicode)
+
     def test_source_unicode(self):
         source = G(Source, name='test', display_name='Test', description='A test source.')
         expected_unicode = 'Test'

--- a/entity_subscription/tests/models_tests.py
+++ b/entity_subscription/tests/models_tests.py
@@ -389,6 +389,11 @@ class UnicodeMethodTests(TestCase):
             Source, name='test', display_name='Test', description='A test source.'
         )
 
+    def test_subscription_unicode(self):
+        sub = G(Subscription, entity=self.entity, medium=self.medium, source=self.source)
+        expected_unicode = 'Entity Test to Test by Test'
+        self.assertEqual(sub.__unicode__(), expected_unicode)
+
     def test_unsubscribe_unicode(self):
         unsub = G(Unsubscribe, entity=self.entity, medium=self.medium, source=self.source)
         expected_unicode = 'Entity Test from Test by Test'

--- a/entity_subscription/tests/models_tests.py
+++ b/entity_subscription/tests/models_tests.py
@@ -375,3 +375,10 @@ class NumberOfQueriesTests(TestCase):
         with self.assertNumQueries(1):
             entities = [e0, e1]
             list(Subscription.objects.filter_not_subscribed(source=s1, medium=m1, entities=entities))
+
+
+class UnicodeMethodTests(TestCase):
+    def test_source_unicode(self):
+        source = G(Source, name='test', display_name='Test', description='A test source.')
+        expected_unicode = 'Test'
+        self.assertEqual(source.__unicode__(), expected_unicode)

--- a/entity_subscription/tests/models_tests.py
+++ b/entity_subscription/tests/models_tests.py
@@ -378,12 +378,26 @@ class NumberOfQueriesTests(TestCase):
 
 
 class UnicodeMethodTests(TestCase):
+    def setUp(self):
+        self.entity = G(
+            Entity, entity_meta={'name': 'Entity Test'}
+        )
+        self.medium = G(
+            Medium, name='test', display_name='Test', description='A test medium.'
+        )
+        self.source = G(
+            Source, name='test', display_name='Test', description='A test source.'
+        )
+
+    def test_unsubscribe_unicode(self):
+        unsub = G(Unsubscribe, entity=self.entity, medium=self.medium, source=self.source)
+        expected_unicode = 'Entity Test from Test by Test'
+        self.assertEqual(unsub.__unicode__(), expected_unicode)
+
     def test_medium_unicode(self):
-        medium = G(Medium, name='test', display_name='Test', description='A test medium.')
         expected_unicode = 'Test'
-        self.assertEqual(medium.__unicode__(), expected_unicode)
+        self.assertEqual(self.medium.__unicode__(), expected_unicode)
 
     def test_source_unicode(self):
-        source = G(Source, name='test', display_name='Test', description='A test source.')
         expected_unicode = 'Test'
-        self.assertEqual(source.__unicode__(), expected_unicode)
+        self.assertEqual(self.source.__unicode__(), expected_unicode)


### PR DESCRIPTION
Add the methods necessary to manage subscriptions from the admin interface.

This includes clear `__unicode__` methods for `Medium`, `Source`, `Subscription`, and `Unsubscribe` objects,  plus easy to read list and update views in the admin panel.
